### PR TITLE
Fix error in binary search

### DIFF
--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -301,16 +301,19 @@ func (rf *Raft) replicateOnceRound(peer int) {
 						if reply.ConflictTerm != -1 {
 							// find nextIndex through binary search
 							firstLogIndex := rf.getFirstLog().Index
+							// find the largest i s.t. term of the log entry with index i is at most reply.ConflictTerm
 							lo, hi := firstLogIndex, args.PrevLogIndex-1
 							for lo < hi {
 								mid := (lo + hi + 1) / 2
-								if rf.logs[mid-firstLogIndex].Term == reply.ConflictTerm {
+								if rf.logs[mid-firstLogIndex].Term <= reply.ConflictTerm {
 									lo = mid
 								} else {
 									hi = mid - 1
 								}
 							}
-							rf.nextIndex[peer] = lo
+							if rf.logs[lo-firstLogIndex].Term == reply.ConflictTerm {
+								rf.nextIndex[peer] = lo
+							}
 						}
 					}
 				} else {


### PR DESCRIPTION
Sorry I was inconsiderate in the last pr.

The condition to check in binary search should actually be `<=`. The binary search algorithm I used is to find a partitioning point $m$ in range $[l, r]$ for a condition $cond$, such that $cond(i) = true , \forall i \in [l, m]$ and $cond(i) = false , \forall i \in (m, r]$, so with `==` the algorithm could fail.

Also, the found entry should be checked after the loop, because in theory (without considering the Raft settings) there could be no matching entry at all.